### PR TITLE
respect the cache option in args array

### DIFF
--- a/get-the-image.php
+++ b/get-the-image.php
@@ -285,7 +285,7 @@ final class Get_The_Image {
 	public function find() {
 
 		/* Get cache key based on $this->args. */
-		$key = md5( serialize( compact( array_keys( $this->args ) ) ) );
+		$key = md5( serialize( $this->args ) );
 
 		/* Check for a cached image. */
 		$image_cache = wp_cache_get( $this->args['post_id'], 'get_the_image' );
@@ -294,7 +294,7 @@ final class Get_The_Image {
 			$image_cache = array();
 
 		/* If there is no cached image, let's see if one exists. */
-		if ( !isset( $image_cache[ $key ] ) || empty( $cache ) ) {
+		if ( !isset( $image_cache[ $key ] ) || empty( $this->args['cache'] ) ) {
 
 			foreach ( $this->args['order'] as $method ) {
 
@@ -334,9 +334,11 @@ final class Get_The_Image {
 				if ( !empty( $this->args['meta_key_save'] ) )
 					$this->meta_key_save();
 
-				/* Set the image cache for the specific post. */
-				$image_cache[ $key ] = $this->image;
-				wp_cache_set( $this->args['post_id'], $image_cache, 'get_the_image' );
+				if ( $this->args['cache'] ) {
+					/* Set the image cache for the specific post. */
+					$image_cache[$key] = $this->image;
+					wp_cache_set( $this->args['post_id'], $image_cache, 'get_the_image' );
+				}
 			}
 		}
 


### PR DESCRIPTION
use proper key to cache images and don't cache when `$args['cache']` is set to `false`
