### PR TITLE
Check wp_get_attachment_image_src() return values in _get_image_attachment()

### DIFF
--- a/get-the-image.php
+++ b/get-the-image.php
@@ -617,6 +617,10 @@ final class Get_The_Image {
 		/* Get the attachment image. */
 		$image = wp_get_attachment_image_src( $attachment_id, $this->args['size'] );
 
+		/* If no image was found, return. */
+		if ( false === $image )
+			return;
+
 		/* Get the attachment alt text. */
 		$alt = trim( strip_tags( get_post_meta( $attachment_id, '_wp_attachment_image_alt', true ) ) );
 


### PR DESCRIPTION
`_get_image_attachment()` could get called with an invalid `$attachment_id` parameter value (for example, when the `get_scan_image()` method extracts an image, the method will pass the complete match first (not just the ID). We need to make sure that we don't set an invalid _image_args_ array in this case.
